### PR TITLE
[Fix version]: Switch form nightly to stable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:nightly-alpine-build
+FROM crystallang/crystal:1.8.1-alpine
 
 # install packages required to run the representer
 RUN apk add --no-cache bash jq coreutils


### PR DESCRIPTION
For a couple of hours ago an outage occurred on the platform. Which was caused by tooling using too much storage, I went and reviewed this one and noticed it used a far more expensive storage version than required. Thereby this pr will bring the tooling to a lighter version.